### PR TITLE
fix: hide actions that shouldn't be available

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,7 +12,7 @@ import {
 import Link from "next/link";
 
 export default function DashboardPage() {
-  const { selectedVenue } = useDashboard();
+  const { selectedVenue, isStandardUser } = useDashboard();
 
   if (!selectedVenue) {
     return (
@@ -20,9 +20,11 @@ export default function DashboardPage() {
         <Card>
           <CardHeader>
             <CardTitle>Welcome to your dashboard</CardTitle>
-            <CardDescription>
-              Please select a venue to get started
-            </CardDescription>
+            {!isStandardUser && (
+              <CardDescription>
+                Please select a venue to get started
+              </CardDescription>
+            )}
           </CardHeader>
         </Card>
       </div>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { VenueType } from "@/types/venue";
 import { Beer, Hop, LayoutPanelLeft, Store, User } from "lucide-react";
 import Link from "next/link";
 import { useDashboard } from "./dashboard/dashboard-provider";
@@ -54,13 +55,16 @@ const breweryItems = [
 ];
 
 export function AppSidebar() {
-  const { selectedVenue } = useDashboard();
+  const { selectedVenue, isStandardUser } = useDashboard();
 
-  const items = selectedVenue?.type === "bar" ? barItems : breweryItems;
+  const items = getSidebarItems(isStandardUser, selectedVenue);
 
   return (
     <Sidebar>
       <SidebarHeader>
+        <Link href="/" className="hidden p-2 font-bold sm:block">
+          pouring<span className="text-amber-500">.</span>at
+        </Link>
         <VenueSearch />
       </SidebarHeader>
       <SidebarContent>
@@ -91,4 +95,15 @@ export function AppSidebar() {
       </SidebarFooter>
     </Sidebar>
   );
+}
+
+function getSidebarItems(
+  isStandardUser: boolean,
+  selectedVenue: { id: string; type: VenueType } | null
+) {
+  if (isStandardUser) {
+    return sharedItems;
+  }
+
+  return selectedVenue?.type === "bar" ? barItems : breweryItems;
 }

--- a/src/components/dashboard/dashboard-provider.tsx
+++ b/src/components/dashboard/dashboard-provider.tsx
@@ -10,6 +10,7 @@ type DashboardContextType = {
   selectedVenue: { id: string; type: VenueType } | null;
   setSelectedVenue: (venue: Venue | null) => void;
   showVenueSelect: boolean;
+  isStandardUser: boolean;
 };
 
 const DashboardContext = createContext<DashboardContextType | null>(null);
@@ -29,6 +30,7 @@ export function DashboardProvider({
 }: DashboardProviderProps) {
   const [selectedVenue, setSelectedVenueState] = useState(defaultVenue ?? null);
 
+  const isStandardUser = !isAdmin && availableVenues.length === 0;
   // Only show venue select if user is admin OR has access to multiple venues
   const showVenueSelect = isAdmin || availableVenues.length > 1;
 
@@ -51,6 +53,7 @@ export function DashboardProvider({
         selectedVenue,
         setSelectedVenue,
         showVenueSelect,
+        isStandardUser,
       }}
     >
       {children}

--- a/src/components/tap-list.tsx
+++ b/src/components/tap-list.tsx
@@ -1,23 +1,29 @@
 import { AddTap } from "@/components/add-tap";
+import { auth } from "@/lib/auth";
 import { getTaps } from "@/lib/taps";
 import { Beer } from "lucide-react";
+import { headers } from "next/headers";
 import Link from "next/link";
 
 export async function TapList({ barId }: { barId: string }) {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
   const taps = await getTaps(barId);
 
   return (
     <div className="mt-8">
       <div className="bg-background mb-4 flex items-center justify-between rounded-lg p-4">
         <h2 className="text-2xl font-bold">Tap list</h2>
-        <AddTap barId={barId} />
+        {session?.user && <AddTap barId={barId} />}
       </div>
       {taps.length === 0 ? (
         <div className="bg-muted grid place-items-center rounded-md px-6 py-12">
           <p className="text-muted-foreground mb-6">
             No beers currently on tap
           </p>
-          <AddTap barId={barId} />
+          {session?.user && <AddTap barId={barId} />}
         </div>
       ) : (
         <ul className="bg-background rounded-lg p-4">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a user type distinction, enabling the app to identify and handle standard users separately from admins or users with venue access.
- **Improvements**
	- Sidebar menu items now adapt based on user type and selected venue for a more personalized navigation experience.
	- The dashboard prompt to select a venue is now shown only to non-standard users.
	- The "Add Tap" option is now visible only to logged-in users.
- **User Interface**
	- Added a styled link to the home page ("pouring.at") in the sidebar header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->